### PR TITLE
Fix pymarkdownlint package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ For more information and updates, visit the official project website: [https://m
   `logging`, `os`, `pathlib`, `re`, `sys` across the tools).
 - `tiktoken`: For the `tools/token_counter.py` script.
 - `black`: For code formatting.
-- `pymarkdownlnt`: For linting Markdown files.
+- `pymarkdownlint`: For linting Markdown files.
 - `chardet`: Optional, for character encoding detection.
 
 You can install all Python dependencies using:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tiktoken
 black
-pymarkdownlnt 
+pymarkdownlint 
 pytest
 chardet  # optional - for encoding detection


### PR DESCRIPTION
## Summary
- fix `pymarkdownlint` name in requirements file
- correct the same typo in the README

## Testing
- `pytest -q` *(fails: command not found)*