### PR TITLE
Add large project workflow docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,8 @@ tmp/
 # Exclude local Cloudflare Workers development files
 workers-site/
 .mf/
+.m1f/
+.1f/
 
 # Exotic encodings test files
 tests/m1f/extracted/exotic_encodings*/

--- a/README.md
+++ b/README.md
@@ -641,6 +641,12 @@ When `--create-archive` is used, the archive will contain all files selected for
 
 For extremely large directories with tens of thousands of files or very large individual files, the script might take some time to process.
 
+### Large Project Workflow Example
+
+When a project has many files, start by creating an inventory using `tools/m1f.py` with `--skip-output-file`. This generates file and directory lists without producing the combined file. Review these lists to decide which parts of the project you want to include in your AI context.
+
+Save selected bundles into a `.m1f` directory at the project root with numbered names such as `1_doc.txt`, `2_template.txt`, or `3_plugin.txt`. Example tasks for automating this process live in `tasks/m1f.json` and are documented in `tasks/README.md`.
+
 ### Project Website
 
 For more information and updates, visit the official project website: [https://m1f.dev](https://m1f.dev)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -405,3 +405,32 @@ maintain your `my_wp_context_files.txt` list as your project evolves.
 This approach helps you provide targeted and relevant information to your AI
 assistant, leading to more accurate and helpful responses for your WordPress
 development tasks.
+
+## Example: Organizing a Large Project with `.m1f`
+
+When dealing with a project that contains hundreds or thousands of files, start
+by generating a complete file and directory listing without creating the merged
+context file. Run the **Project Review: Generate Lists** task. It calls
+`tools/m1f.py` with `--skip-output-file` and saves two inventory files to the
+`.m1f` directory:
+
+- `.m1f/project_review_filelist.txt`
+- `.m1f/project_review_dirlist.txt`
+
+Review these lists and decide which areas of the project you want to load into
+your AI assistant. Typical numbered context files might include:
+
+- `1_doc.txt` – the full documentation bundle
+- `2_template.txt` – template files from your theme
+- `3_plugin.txt` – a specific plugin or a group of plugins
+
+Store each generated context file in the `.m1f` folder with a number prefix for
+quick referencing in Windsurf, Cursor, or Claude (for example
+`@.m1f/1_doc.txt`).
+
+To keep the inventory current during development, launch **Project Review: Watch
+for Changes**. This background watcher reruns the list generation whenever files
+are modified.
+
+Remember to add `.m1f/` (and `.1f/` if used) to your `.gitignore` so these
+helper files stay out of version control.

--- a/tasks/m1f.json
+++ b/tasks/m1f.json
@@ -189,6 +189,43 @@
                 "clear": true
             },
             "detail": "Creates a combined AI context file containing both theme and plugin files for a complete WordPress project."
+        },
+        {
+            "label": "Project Review: Generate Lists",
+            "type": "shell",
+            "command": "python",
+            "args": [
+                "${workspaceFolder}/tools/m1f.py",
+                "--source-directory",
+                "${workspaceFolder}",
+                "--output-file",
+                "${workspaceFolder}/.m1f/project_review.m1f.txt",
+                "--skip-output-file",
+                "--verbose"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "detail": "Generates full project file and directory listings in the .m1f directory."
+        },
+        {
+            "label": "Project Review: Watch for Changes",
+            "type": "shell",
+            "command": "watchmedo",
+            "args": [
+                "shell-command",
+                "--patterns=*.py;*.md;*",
+                "--recursive",
+                "--command",
+                "python ${workspaceFolder}/tools/m1f.py --source-directory ${workspaceFolder} --output-file ${workspaceFolder}/.m1f/project_review.m1f.txt --skip-output-file --quiet"
+            ],
+            "problemMatcher": [],
+            "isBackground": true,
+            "group": "build",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            },
+            "detail": "Watches for file changes and regenerates the project review lists."
         }
     ]
-} 
+}

--- a/tests/m1f/source/exotic_encodings/exotic_encoding_test_results.md
+++ b/tests/m1f/source/exotic_encodings/exotic_encoding_test_results.md
@@ -2,24 +2,26 @@
 
 ## Overview
 
-This document summarizes the results of testing the m1f/s1f tools with files in exotic character encodings.
+This document summarizes the results of testing the m1f/s1f tools with files in
+exotic character encodings.
 
 ## Test Files
 
 We created test files in the following exotic encodings:
 
-| Filename | Encoding | Description |
-|----------|----------|-------------|
-| shiftjis.txt | Shift-JIS | Japanese encoding |
-| big5.txt | Big5 | Traditional Chinese encoding |
-| koi8r.txt | KOI8-R | Russian encoding |
-| iso8859-8.txt | ISO-8859-8 | Hebrew encoding |
-| euckr.txt | EUC-KR | Korean encoding |
-| windows1256.txt | Windows-1256 | Arabic encoding |
+| Filename        | Encoding     | Description                  |
+| --------------- | ------------ | ---------------------------- |
+| shiftjis.txt    | Shift-JIS    | Japanese encoding            |
+| big5.txt        | Big5         | Traditional Chinese encoding |
+| koi8r.txt       | KOI8-R       | Russian encoding             |
+| iso8859-8.txt   | ISO-8859-8   | Hebrew encoding              |
+| euckr.txt       | EUC-KR       | Korean encoding              |
+| windows1256.txt | Windows-1256 | Arabic encoding              |
 
 ## Test 1: m1f Encoding Detection and Conversion
 
-We used m1f to combine these files with automatic encoding detection and conversion to UTF-8:
+We used m1f to combine these files with automatic encoding detection and
+conversion to UTF-8:
 
 ```bash
 python m1f.py --source-directory ./exotic_encodings --output-file ./output/exotic_encodings_test.txt --separator-style MachineReadable --convert-to-charset utf-8
@@ -28,8 +30,9 @@ python m1f.py --source-directory ./exotic_encodings --output-file ./output/exoti
 ### Results:
 
 - m1f successfully detected the original encodings of all files
-- All files were converted to UTF-8 
-- The conversion process had some errors (indicated by `"had_encoding_errors": true` in the metadata)
+- All files were converted to UTF-8
+- The conversion process had some errors (indicated by
+  `"had_encoding_errors": true` in the metadata)
 - The original encoding information was preserved in the metadata
 
 ## Test 2: s1f Extraction with Default Settings
@@ -44,7 +47,8 @@ python s1f.py --input-file ./output/exotic_encodings_test.txt --destination-dire
 
 - All files were successfully extracted
 - All files were saved as UTF-8
-- The file content was readable as UTF-8, though with some encoding artifacts from the conversion process
+- The file content was readable as UTF-8, though with some encoding artifacts
+  from the conversion process
 
 ## Test 3: s1f Extraction with Respect to Original Encoding
 
@@ -62,21 +66,31 @@ python s1f.py --input-file ./output/exotic_encodings_test.txt --destination-dire
   - big5.txt: Successfully restored to Big5 encoding
   - koi8r.txt: Successfully restored to KOI8-R encoding
   - windows1256.txt: Successfully restored to Windows-1256 encoding
-  - shiftjis.txt, euckr.txt, iso8859-8.txt: Could not be properly restored to their original encodings
+  - shiftjis.txt, euckr.txt, iso8859-8.txt: Could not be properly restored to
+    their original encodings
 
 ## Conclusions
 
-1. The m1f tool successfully detects and handles exotic encodings, though conversion to UTF-8 can result in some character loss or transformation.
+1. The m1f tool successfully detects and handles exotic encodings, though
+   conversion to UTF-8 can result in some character loss or transformation.
 
-2. The s1f tool can extract files either as UTF-8 or try to respect their original encodings.
+2. The s1f tool can extract files either as UTF-8 or try to respect their
+   original encodings.
 
-3. Round-trip conversion (original encoding → UTF-8 → original encoding) is not perfect for all encodings, especially when there were encoding errors in the first conversion.
+3. Round-trip conversion (original encoding → UTF-8 → original encoding) is not
+   perfect for all encodings, especially when there were encoding errors in the
+   first conversion.
 
 4. The `--respect-encoding` option in s1f works best when:
+
    - The original file's encoding is accurately detected by m1f
    - The conversion to UTF-8 happened without encoding errors
    - The encoding is well-supported by Python's encoding/decoding functions
 
-5. For most practical purposes, the default UTF-8 extraction is sufficient and more reliable, especially when working with text that will be processed by modern tools (which typically expect UTF-8).
+5. For most practical purposes, the default UTF-8 extraction is sufficient and
+   more reliable, especially when working with text that will be processed by
+   modern tools (which typically expect UTF-8).
 
-This test demonstrates that the m1f/s1f tools are capable of handling exotic encodings and provide options for both standardizing to UTF-8 and attempting to preserve original encodings. 
+This test demonstrates that the m1f/s1f tools are capable of handling exotic
+encodings and provide options for both standardizing to UTF-8 and attempting to
+preserve original encodings.

--- a/tests/m1f/source/exotic_encodings/exotic_encoding_test_results_updated.md
+++ b/tests/m1f/source/exotic_encodings/exotic_encoding_test_results_updated.md
@@ -2,38 +2,49 @@
 
 ## Overview
 
-This document summarizes the results of testing the m1f/s1f tools with files in exotic character encodings, using UTF-16-LE as the intermediate encoding format. This addresses a critical requirement when handling diverse character sets.
+This document summarizes the results of testing the m1f/s1f tools with files in
+exotic character encodings, using UTF-16-LE as the intermediate encoding format.
+This addresses a critical requirement when handling diverse character sets.
 
 ## Test Files
 
 We created test files in the following exotic encodings:
 
-| Filename | Encoding | Description |
-|----------|----------|-------------|
-| shiftjis.txt | Shift-JIS | Japanese encoding |
-| big5.txt | Big5 | Traditional Chinese encoding |
-| koi8r.txt | KOI8-R | Russian encoding |
-| iso8859-8.txt | ISO-8859-8 | Hebrew encoding |
-| euckr.txt | EUC-KR | Korean encoding |
-| windows1256.txt | Windows-1256 | Arabic encoding |
+| Filename        | Encoding     | Description                  |
+| --------------- | ------------ | ---------------------------- |
+| shiftjis.txt    | Shift-JIS    | Japanese encoding            |
+| big5.txt        | Big5         | Traditional Chinese encoding |
+| koi8r.txt       | KOI8-R       | Russian encoding             |
+| iso8859-8.txt   | ISO-8859-8   | Hebrew encoding              |
+| euckr.txt       | EUC-KR       | Korean encoding              |
+| windows1256.txt | Windows-1256 | Arabic encoding              |
 
 ## Why UTF-16-LE is Better Than UTF-8
 
-UTF-16-LE is superior to UTF-8 when handling diverse character sets for several reasons:
+UTF-16-LE is superior to UTF-8 when handling diverse character sets for several
+reasons:
 
-1. **Complete Unicode Coverage**: UTF-16 can represent all Unicode code points, including characters in the astral planes that UTF-8 might struggle with.
+1. **Complete Unicode Coverage**: UTF-16 can represent all Unicode code points,
+   including characters in the astral planes that UTF-8 might struggle with.
 
-2. **Efficiency for Many Languages**: While UTF-8 is more efficient for ASCII text, UTF-16 is more efficient for many Asian and Middle Eastern scripts, which require multiple bytes per character in UTF-8.
+2. **Efficiency for Many Languages**: While UTF-8 is more efficient for ASCII
+   text, UTF-16 is more efficient for many Asian and Middle Eastern scripts,
+   which require multiple bytes per character in UTF-8.
 
-3. **BOM Support**: UTF-16 supports a Byte Order Mark (BOM), which helps identify encoding more reliably when working with different character sets.
+3. **BOM Support**: UTF-16 supports a Byte Order Mark (BOM), which helps
+   identify encoding more reliably when working with different character sets.
 
-4. **Consistent Byte Order**: UTF-16-LE explicitly defines byte order, reducing ambiguity in the encoding process.
+4. **Consistent Byte Order**: UTF-16-LE explicitly defines byte order, reducing
+   ambiguity in the encoding process.
 
-5. **Better Preservation**: Our tests confirm that UTF-16-LE preserves exotic character encodings more accurately than UTF-8 when used as an intermediate format.
+5. **Better Preservation**: Our tests confirm that UTF-16-LE preserves exotic
+   character encodings more accurately than UTF-8 when used as an intermediate
+   format.
 
 ## Test 1: m1f Encoding Detection and Conversion with UTF-16-LE
 
-We used m1f to combine files with automatic encoding detection and conversion to UTF-16-LE:
+We used m1f to combine files with automatic encoding detection and conversion to
+UTF-16-LE:
 
 ```bash
 python m1f.py --source-directory ./exotic_encodings --output-file ./output/exotic_encodings_test.txt --separator-style MachineReadable --convert-to-charset utf-16-le
@@ -58,48 +69,60 @@ python s1f.py --input-file ./output/exotic_encodings_test.txt --destination-dire
 
 - All files were successfully extracted
 - Superior encoding preservation compared to UTF-8:
+
   - big5.txt: Successfully restored to Big5 encoding
   - koi8r.txt: Successfully restored to KOI8-R encoding
   - windows1256.txt: Successfully restored to Windows-1256 encoding
 
-- Some files (shiftjis.txt, euckr.txt, iso8859-8.txt) still had issues which may be related to BOM handling
+- Some files (shiftjis.txt, euckr.txt, iso8859-8.txt) still had issues which may
+  be related to BOM handling
 
 ## Comparison with UTF-8 Conversion
 
 The difference in results is significant:
 
-| Encoding | UTF-8 Round-Trip | UTF-16-LE Round-Trip |
-|----------|-----------------|---------------------|
-| big5 | Failed | Successful |
-| koi8_r | Partially Successful | Successful |
-| windows1256 | Partially Successful | Successful |
-| shift_jis | Failed | Better but still issues |
-| euc_kr | Failed | Better but still issues |
-| iso8859-8 | Failed | Better but still issues |
+| Encoding    | UTF-8 Round-Trip     | UTF-16-LE Round-Trip    |
+| ----------- | -------------------- | ----------------------- |
+| big5        | Failed               | Successful              |
+| koi8_r      | Partially Successful | Successful              |
+| windows1256 | Partially Successful | Successful              |
+| shift_jis   | Failed               | Better but still issues |
+| euc_kr      | Failed               | Better but still issues |
+| iso8859-8   | Failed               | Better but still issues |
 
 ## Conclusions
 
-1. UTF-16-LE is significantly more effective than UTF-8 as an intermediate encoding format for handling diverse character sets.
+1. UTF-16-LE is significantly more effective than UTF-8 as an intermediate
+   encoding format for handling diverse character sets.
 
-2. When working with multiple different encodings in the m1f/s1f toolset, the `--convert-to-charset utf-16-le` option should be preferred over UTF-8.
+2. When working with multiple different encodings in the m1f/s1f toolset, the
+   `--convert-to-charset utf-16-le` option should be preferred over UTF-8.
 
-3. The `--respect-encoding` option in s1f works best when combined with UTF-16-LE conversion in m1f, especially for:
+3. The `--respect-encoding` option in s1f works best when combined with
+   UTF-16-LE conversion in m1f, especially for:
+
    - Big5 (Traditional Chinese)
    - KOI8-R (Russian)
    - Windows-1256 (Arabic)
 
-4. Further improvements could be made for handling Shift-JIS, EUC-KR, and ISO-8859-8 encodings, potentially by adding explicit BOM handling.
+4. Further improvements could be made for handling Shift-JIS, EUC-KR, and
+   ISO-8859-8 encodings, potentially by adding explicit BOM handling.
 
-5. For production environments working with multiple encodings, UTF-16-LE should be the default conversion target.
+5. For production environments working with multiple encodings, UTF-16-LE should
+   be the default conversion target.
 
 ## Automated Test
 
-An automated test has been added to the main test suite (`test_encoding_conversion.py`) to verify this functionality in the future. This test:
+An automated test has been added to the main test suite
+(`test_encoding_conversion.py`) to verify this functionality in the future. This
+test:
 
-1. Verifies that m1f can properly handle exotic encodings with UTF-16-LE conversion
+1. Verifies that m1f can properly handle exotic encodings with UTF-16-LE
+   conversion
 2. Ensures that all test files are properly processed and included in the output
 3. Confirms that all files are correctly converted to UTF-16-LE format
-4. Includes a documentation test that reminds developers to use UTF-16-LE for better encoding preservation
+4. Includes a documentation test that reminds developers to use UTF-16-LE for
+   better encoding preservation
 
 The test passes successfully in the pytest framework and can be run with:
 
@@ -107,4 +130,6 @@ The test passes successfully in the pytest framework and can be run with:
 pytest -xvs tests/m1f/test_encoding_conversion.py
 ```
 
-This test is now part of the main test suite and will help ensure that the superior UTF-16-LE handling of exotic encodings is maintained in future versions of the tools. 
+This test is now part of the main test suite and will help ensure that the
+superior UTF-16-LE handling of exotic encodings is maintained in future versions
+of the tools.


### PR DESCRIPTION
## Summary
- ignore `.m1f` directory
- document large project workflow in `README.md`
- extend `tasks/README.md` with `.m1f` usage example
- add tasks in `tasks/m1f.json` to generate and watch project lists
- format Markdown files with Prettier

## Testing
- `npm run lint:md:check`
- `python -m pytest tests/m1f/test_m1f.py -q` *(fails: No module named pytest)*