### PR TITLE
Add optional security check

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ formatting.
 | `-q, --quiet`            | Suppress all console output                                                                                                                                                                                                               |
 | `--create-archive`       | Create a backup archive of all processed files                                                                                                                                                                                            |
 | `--archive-type`         | Type of archive to create (`zip` or `tar.gz`)                                                                                                                                                                                             |
+| `--security-check`      | Scan files for secrets before merging (`abort`, `skip`, `warn`) |
 
 #### Usage Examples
 
@@ -263,6 +264,26 @@ Versioning with content hash based on included files:
 python tools/m1f.py -s ./project -o ./snapshots/project.txt \
   --filename-mtime-hash
 ```
+
+Checking for secrets and aborting if any are found:
+
+```bash
+python tools/m1f.py -s ./project -o ./clean.txt \
+  --security-check abort
+```
+
+### Security Check
+
+The `--security-check` option scans files for potential secrets using
+`detect-secrets` if the library is installed. When secrets are detected you can
+decide how the script proceeds:
+
+- `abort` – stop processing immediately and do not create the output file.
+- `skip` – omit files that contain secrets from the final output.
+- `warn` – include all files but print a summary warning at the end.
+
+If `detect-secrets` is not available, a simplified pattern-based scan is used as
+a fallback.
 
 ### Output Files
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tiktoken
 black
-pymarkdownlnt 
+pymarkdownlnt
 pytest
 chardet  # optional - for encoding detection
+detect-secrets  # optional - for secret scanning

--- a/tests/m1f/test_security_check.py
+++ b/tests/m1f/test_security_check.py
@@ -1,0 +1,65 @@
+import sys
+import logging
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("detect_secrets")
+
+# Reuse helper from main test suite
+from tests.m1f.test_m1f import run_m1f, SOURCE_DIR, OUTPUT_DIR
+
+def test_security_check_abort():
+    output_file = OUTPUT_DIR / "security_abort.txt"
+    run_m1f([
+        "--source-directory",
+        str(SOURCE_DIR),
+        "--output-file",
+        str(output_file),
+        "--include-dot-paths",
+        "--security-check",
+        "abort",
+        "--force",
+    ])
+    assert not output_file.exists(), "Output file should not be created when aborting"
+
+
+def test_security_check_skip():
+    output_file = OUTPUT_DIR / "security_skip.txt"
+    run_m1f([
+        "--source-directory",
+        str(SOURCE_DIR),
+        "--output-file",
+        str(output_file),
+        "--include-dot-paths",
+        "--security-check",
+        "skip",
+        "--force",
+    ])
+    assert output_file.exists(), "Output file missing when skipping"
+    with open(output_file, "r", encoding="utf-8") as f:
+        content = f.read()
+        assert "SECRET_KEY" not in content
+
+
+def test_security_check_warn():
+    output_file = OUTPUT_DIR / "security_warn.txt"
+    run_m1f([
+        "--source-directory",
+        str(SOURCE_DIR),
+        "--output-file",
+        str(output_file),
+        "--include-dot-paths",
+        "--security-check",
+        "warn",
+        "--force",
+    ])
+    assert output_file.exists(), "Output file missing when warning"
+    with open(output_file, "r", encoding="utf-8") as f:
+        content = f.read()
+        assert "SECRET_KEY" in content
+    log_file = output_file.with_suffix(".log")
+    if log_file.exists():
+        with open(log_file, "r", encoding="utf-8") as log:
+            log_content = log.read()
+            assert "SECURITY WARNING" in log_content

--- a/tests/m1f/test_security_check.py
+++ b/tests/m1f/test_security_check.py
@@ -11,16 +11,17 @@ from tests.m1f.test_m1f import run_m1f, SOURCE_DIR, OUTPUT_DIR
 
 def test_security_check_abort():
     output_file = OUTPUT_DIR / "security_abort.txt"
-    run_m1f([
-        "--source-directory",
-        str(SOURCE_DIR),
-        "--output-file",
-        str(output_file),
-        "--include-dot-paths",
-        "--security-check",
-        "abort",
-        "--force",
-    ])
+    with pytest.raises(SystemExit):
+        run_m1f([
+            "--source-directory",
+            str(SOURCE_DIR),
+            "--output-file",
+            str(output_file),
+            "--include-dot-paths",
+            "--security-check",
+            "abort",
+            "--force",
+        ])
     assert not output_file.exists(), "Output file should not be created when aborting"
 
 

--- a/tools/m1f.py
+++ b/tools/m1f.py
@@ -2317,7 +2317,6 @@ def main():
                 if not args.quiet:
                     print(message)
                 sys.exit(1)
-                return
             elif args.security_check == "skip":
                 logger.warning(
                     f"Skipping {len(flagged)} file(s) due to security check."

--- a/tools/m1f.py
+++ b/tools/m1f.py
@@ -200,6 +200,7 @@ import os
 import sys
 import time  # Added for time measurement
 import uuid  # Added for UUID generation
+import re
 from pathlib import Path
 from typing import List, Set, Tuple, Optional
 import tiktoken  # Added for token counting
@@ -213,6 +214,14 @@ try:
     CHARDET_AVAILABLE = True
 except ImportError:
     CHARDET_AVAILABLE = False
+
+# Try to import detect_secrets for optional security scanning
+try:
+    from detect_secrets.core.scan import scan_file
+    from detect_secrets.settings import get_settings
+    DETECT_SECRETS_AVAILABLE = True
+except Exception:  # pragma: no cover - library might not be installed
+    DETECT_SECRETS_AVAILABLE = False
 
 # --- Logger Setup ---
 logger = logging.getLogger("m1f")
@@ -378,6 +387,48 @@ def _count_tokens_in_file_content(
 
 
 # --- Helper Functions ---
+
+SENSITIVE_PATTERNS = [
+    re.compile(r"password\s*[=:]\s*\S+", re.IGNORECASE),
+    re.compile(r"secret[_-]?key\s*[=:]\s*\S+", re.IGNORECASE),
+    re.compile(r"api[_-]?key\s*[=:]\s*\S+", re.IGNORECASE),
+    re.compile(r"token\s*[=:]\s*\S+", re.IGNORECASE),
+]
+
+
+def _contains_sensitive_info(text: str) -> bool:
+    """Return True if the text contains potentially sensitive information."""
+    for pattern in SENSITIVE_PATTERNS:
+        if pattern.search(text):
+            return True
+    return False
+
+
+def _scan_files_for_sensitive_info(
+    files_to_process: list[tuple[Path, str]],
+) -> list[str]:
+    """Scan files for sensitive information and return list of relative paths."""
+    flagged: list[str] = []
+    if DETECT_SECRETS_AVAILABLE:
+        for abs_path, rel_path in files_to_process:
+            try:
+                findings = scan_file(str(abs_path), get_settings())
+            except Exception as e:  # pragma: no cover - scanning error
+                logger.warning(f"detect-secrets failed on {abs_path}: {e}")
+                continue
+            if findings:
+                flagged.append(rel_path)
+    else:
+        for abs_path, rel_path in files_to_process:
+            try:
+                content = abs_path.read_text(encoding="utf-8", errors="ignore")
+            except Exception as e:  # pragma: no cover - unlikely read error
+                logger.warning(f"Could not read {abs_path} for security check: {e}")
+                continue
+            if _contains_sensitive_info(content):
+                flagged.append(rel_path)
+    return flagged
+
 
 def _detect_file_encoding(file_path: Path, verbose: bool = False) -> str:
     """
@@ -2115,6 +2166,15 @@ def main():
         default="zip",
         help="Type of archive to create if --create-archive is specified. Default: zip.",
     )
+    parser.add_argument(
+        "--security-check",
+        choices=["abort", "skip", "warn"],
+        help=(
+            "Check files for common secrets before merging. "
+            "'abort': stop processing if secrets are found; no files are written. "
+            "'skip': exclude affected files. 'warn': include files but report at the end."
+        ),
+    )
 
     input_group = parser.add_mutually_exclusive_group(required=True)
     input_group.add_argument(
@@ -2220,6 +2280,30 @@ def main():
         excluded_file_paths=excluded_file_paths,
         gitignore_spec=gitignore_spec,
     )
+
+    # --- Security Check ---
+    if getattr(args, "security_check", None):
+        flagged = _scan_files_for_sensitive_info(files_to_process)
+        if flagged:
+            if args.security_check == "abort":
+                message = (
+                    "Security check failed. Sensitive information detected in: "
+                    + ", ".join(flagged)
+                )
+                logger.error(message)
+                if not args.quiet:
+                    print(message)
+                sys.exit(1)
+                return
+            elif args.security_check == "skip":
+                logger.warning(
+                    f"Skipping {len(flagged)} file(s) due to security check."
+                )
+                files_to_process = [
+                    item for item in files_to_process if item[1] not in flagged
+                ]
+            else:  # warn
+                args.flagged_files = flagged
 
     # ---- START: Modification for filename-mtime-hash ----
     if args.filename_mtime_hash and files_to_process:
@@ -2353,6 +2437,15 @@ def main():
         logger.info(
             "Archive creation requested, but no files were processed. Skipping archive creation."
         )
+
+    if getattr(args, "security_check", None) == "warn" and getattr(args, "flagged_files", []):
+        warning_msg = (
+            f"SECURITY WARNING: Sensitive information detected in {len(args.flagged_files)} file(s):\n"
+            + "\n".join(args.flagged_files)
+        )
+        logger.warning(warning_msg)
+        if not args.quiet:
+            print(warning_msg)
 
     # Calculate and log the execution time
     end_time = time.time()


### PR DESCRIPTION
## Summary
- add optional `--security-check` flag for m1f.py to scan for secrets
- use `detect-secrets` when available and fallback to regex
- expand README with a new Security Check section
- add detect-secrets to requirements
- skip security tests when detect-secrets is missing

## Testing
- `python -m pytest -k security_check_abort -q` *(fails: No module named pytest)*