### PR TITLE
Refactor path normalization

### DIFF
--- a/tools/m1f.py
+++ b/tools/m1f.py
@@ -202,6 +202,8 @@ import sys
 import time  # Added for time measurement
 import uuid  # Added for UUID generation
 from pathlib import Path, PureWindowsPath
+
+from path_utils import normalize_path
 from typing import List, Set, Tuple, Optional
 import tiktoken  # Added for token counting
 import zipfile  # Added for archive creation
@@ -1489,7 +1491,7 @@ def _gather_files_to_process(
                     gitignore_spec,
                     explicitly_included=True  # File paths from input file are explicitly included
                 ):
-                    files_to_process.append((item_path, PureWindowsPath(item_path.name).as_posix()))
+                    files_to_process.append((item_path, normalize_path(item_path)))
                     added_file_absolute_paths.add(abs_path_str)
                 # else: _is_file_excluded logs if verbose
 
@@ -1645,9 +1647,7 @@ def _write_file_paths_list(
     logger.info(f"Writing file paths list to {file_list_path}")
 
     # Extract unique relative paths and sort them
-    unique_paths = sorted(
-        set(PureWindowsPath(rel_path).as_posix() for _, rel_path in files_to_process)
-    )
+    unique_paths = sorted(set(normalize_path(rel_path) for _, rel_path in files_to_process))
 
     with open(file_list_path, "w", encoding="utf-8") as f:
         for rel_path in unique_paths:
@@ -1694,7 +1694,7 @@ def _write_directory_paths_list(
 
     for _, rel_path in files_to_process:
         # Get the parent directory of each file
-        normalized = PureWindowsPath(rel_path).as_posix()
+        normalized = normalize_path(rel_path)
         path_obj = Path(normalized)
         # Add all parent directories
         current_path = path_obj.parent

--- a/tools/path_utils.py
+++ b/tools/path_utils.py
@@ -1,0 +1,11 @@
+from pathlib import Path, PureWindowsPath
+
+
+def convert_to_posix_path(path_val: str) -> str:
+    """Convert a path string to POSIX style."""
+    return PureWindowsPath(path_val).as_posix()
+
+
+def normalize_path(path: Path | str) -> str:
+    """Normalize a Path or path-like object to POSIX style."""
+    return PureWindowsPath(str(path)).as_posix()

--- a/tools/s1f.py
+++ b/tools/s1f.py
@@ -94,6 +94,8 @@ import os
 import re
 import sys
 from pathlib import Path, PureWindowsPath
+
+from path_utils import convert_to_posix_path
 from datetime import datetime, timezone
 
 # --- Logger Setup ---
@@ -327,7 +329,7 @@ def parse_combined_file(content: str) -> list[dict]:
 
                     # Extract path from metadata
                     path_val = meta.get("original_filepath", "").strip()
-                    path_val = PureWindowsPath(path_val).as_posix()
+                    path_val = convert_to_posix_path(path_val)
 
                     # Check if we have a valid path
                     if not path_val:
@@ -371,7 +373,7 @@ def parse_combined_file(content: str) -> list[dict]:
                 try:
                     # Get the path directly from the regex match
                     path_val = match.group(pattern_info["path_group"]).strip()
-                    path_val = PureWindowsPath(path_val).as_posix()
+                    path_val = convert_to_posix_path(path_val)
 
                     # Get metadata from JSON
                     json_str = match.group(pattern_info["json_group"])
@@ -411,7 +413,7 @@ def parse_combined_file(content: str) -> list[dict]:
                     continue
             else:
                 path_val = match.group(pattern_info["path_group"]).strip()
-                path_val = PureWindowsPath(path_val).as_posix()
+                path_val = convert_to_posix_path(path_val)
                 
                 # Extract encoding if available
                 if (
@@ -705,7 +707,7 @@ def _write_extracted_files(
     )
     for file_data in extracted_files_data:
         relative_path_str = file_data["path"]
-        normalized = PureWindowsPath(relative_path_str).as_posix()
+        normalized = convert_to_posix_path(relative_path_str)
         file_content_to_write = file_data["content"]
         original_checksum = file_data.get("checksum_sha256")
         original_size_bytes = file_data.get("size_bytes")


### PR DESCRIPTION
## Summary
- add `path_utils` module with reusable path conversion helpers
- refactor `s1f.py` to use `convert_to_posix_path`
- refactor `m1f.py` to use `normalize_path`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*