### PR TITLE
Consolidate POSIX path helpers

### DIFF
--- a/tools/m1f.py
+++ b/tools/m1f.py
@@ -202,9 +202,9 @@ import sys
 import time  # Added for time measurement
 import uuid  # Added for UUID generation
 import re
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 
-from path_utils import normalize_path
+from path_utils import to_posix_path
 from typing import List, Set, Tuple, Optional
 import tiktoken  # Added for token counting
 import zipfile  # Added for archive creation
@@ -1542,7 +1542,7 @@ def _gather_files_to_process(
                     gitignore_spec,
                     explicitly_included=True  # File paths from input file are explicitly included
                 ):
-                    files_to_process.append((item_path, normalize_path(item_path)))
+                    files_to_process.append((item_path, to_posix_path(item_path)))
                     added_file_absolute_paths.add(abs_path_str)
                 # else: _is_file_excluded logs if verbose
 
@@ -1698,7 +1698,7 @@ def _write_file_paths_list(
     logger.info(f"Writing file paths list to {file_list_path}")
 
     # Extract unique relative paths and sort them
-    unique_paths = sorted(set(normalize_path(rel_path) for _, rel_path in files_to_process))
+    unique_paths = sorted(set(to_posix_path(rel_path) for _, rel_path in files_to_process))
 
     with open(file_list_path, "w", encoding="utf-8") as f:
         for rel_path in unique_paths:
@@ -1745,7 +1745,7 @@ def _write_directory_paths_list(
 
     for _, rel_path in files_to_process:
         # Get the parent directory of each file
-        normalized = normalize_path(rel_path)
+        normalized = to_posix_path(rel_path)
         path_obj = Path(normalized)
         # Add all parent directories
         current_path = path_obj.parent

--- a/tools/path_utils.py
+++ b/tools/path_utils.py
@@ -1,11 +1,30 @@
 from pathlib import Path, PureWindowsPath
 
 
+def to_posix_path(path: Path | str) -> str:
+    """Convert a ``Path`` or path-like object to POSIX style.
+
+    This function accepts both strings and ``Path`` objects, normalizing them
+    to a POSIX-style path representation.
+    """
+    return PureWindowsPath(str(path)).as_posix()
+
+
 def convert_to_posix_path(path_val: str) -> str:
-    """Convert a path string to POSIX style."""
-    return PureWindowsPath(path_val).as_posix()
+    """Return ``path_val`` normalized to POSIX style.
+
+    This wrapper is kept for backward compatibility and simply calls
+    :func:`to_posix_path`.
+    """
+
+    return to_posix_path(path_val)
 
 
 def normalize_path(path: Path | str) -> str:
-    """Normalize a Path or path-like object to POSIX style."""
-    return PureWindowsPath(str(path)).as_posix()
+    """Normalize a ``Path`` or path-like object to POSIX style.
+
+    This wrapper is kept for backward compatibility and simply calls
+    :func:`to_posix_path`.
+    """
+
+    return to_posix_path(path)

--- a/tools/s1f.py
+++ b/tools/s1f.py
@@ -93,9 +93,9 @@ import logging
 import os
 import re
 import sys
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 
-from path_utils import convert_to_posix_path
+from path_utils import to_posix_path
 from datetime import datetime, timezone
 
 # --- Logger Setup ---
@@ -329,7 +329,7 @@ def parse_combined_file(content: str) -> list[dict]:
 
                     # Extract path from metadata
                     path_val = meta.get("original_filepath", "").strip()
-                    path_val = convert_to_posix_path(path_val)
+                    path_val = to_posix_path(path_val)
 
                     # Check if we have a valid path
                     if not path_val:
@@ -373,7 +373,7 @@ def parse_combined_file(content: str) -> list[dict]:
                 try:
                     # Get the path directly from the regex match
                     path_val = match.group(pattern_info["path_group"]).strip()
-                    path_val = convert_to_posix_path(path_val)
+                    path_val = to_posix_path(path_val)
 
                     # Get metadata from JSON
                     json_str = match.group(pattern_info["json_group"])
@@ -413,7 +413,7 @@ def parse_combined_file(content: str) -> list[dict]:
                     continue
             else:
                 path_val = match.group(pattern_info["path_group"]).strip()
-                path_val = convert_to_posix_path(path_val)
+                path_val = to_posix_path(path_val)
                 
                 # Extract encoding if available
                 if (
@@ -707,7 +707,7 @@ def _write_extracted_files(
     )
     for file_data in extracted_files_data:
         relative_path_str = file_data["path"]
-        normalized = convert_to_posix_path(relative_path_str)
+        normalized = to_posix_path(relative_path_str)
         file_content_to_write = file_data["content"]
         original_checksum = file_data.get("checksum_sha256")
         original_size_bytes = file_data.get("size_bytes")


### PR DESCRIPTION
## Summary
- unify path normalization logic into `to_posix_path`
- use new helper across the codebase
- keep existing names as wrappers for backward compatibility
- remove unused `PureWindowsPath` imports

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*