### PR TITLE
Add max directory depth option to m1f

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ formatting.
 | `--no-default-excludes`     | Disable default directory exclusions. By default, the following directories are excluded: vendor, node_modules, build, dist, cache, .git, .svn, .hg, \***\*pycache\*\***                                                                                         |
 | `--excludes`                | Space-separated list of paths to exclude. Supports directory names, exact file paths, and gitignore-style patterns (e.g., `--excludes logs "config/settings.json" "*.log" "build/" "!important.log"`)                                                            |
 | `--include-dot-paths`       | Include files and directories that start with a dot (e.g., .gitignore, .hidden/). By default, all dot files and directories are excluded.                                                                                                                        |
+| `--max-depth`               | Limit directory traversal to this depth. Must be non-negative. Paths deeper than this level are skipped. No limit by default. |
 | `--include-binary-files`    | Attempt to include files with binary extensions                                                                                                                                                                                                                  |
 | `--separator-style`         | Style of separators between files (`Standard`, `Detailed`, `Markdown`, `MachineReadable`, `None`)                                                                                                                                                                |
 | `--line-ending`             | Line ending for script-generated separators (`lf` or `crlf`)                                                                                                                                                                                                     |
@@ -280,6 +281,13 @@ Including dot files and directories:
 ```bash
 python tools/m1f.py -s ./project -o ./with_dotfiles.txt \
   --include-dot-paths
+```
+
+Limiting directory traversal depth:
+
+```bash
+python tools/m1f.py -s ./project -o ./top_two_levels.txt \
+  --max-depth 2
 ```
 
 Generating only the combined file with no auxiliary files:

--- a/tests/m1f/test_m1f.py
+++ b/tests/m1f/test_m1f.py
@@ -543,7 +543,30 @@ class TestM1F:
 
         # Clean up
         shutil.rmtree(test_dir)
-        gitignore_file.unlink()
+
+    def test_max_depth(self):
+        """Test limiting directory traversal depth."""
+        output_file = OUTPUT_DIR / "max_depth.txt"
+
+        run_m1f(
+            [
+                "--source-directory",
+                str(SOURCE_DIR / "advanced_glob_test"),
+                "--output-file",
+                str(output_file),
+                "--max-depth",
+                "2",
+                "--force",
+            ]
+        )
+
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+            assert "file.with.dots.txt" in content, "Depth 2 files should be included"
+            assert "nested.js" not in content, "Files deeper than max depth should be excluded"
+            assert "deep_file.txt" not in content, "Deep files should be excluded"
+
+        output_file.unlink()
 
     def test_actual_gitignore_file(self):
         """Test using an actual .gitignore file with exclude-paths-file."""

--- a/tools/m1f.py
+++ b/tools/m1f.py
@@ -2978,7 +2978,7 @@ def main():
         "--max-depth",
         type=_non_negative_int,
         metavar="N",
-        help="Maximum directory depth to scan. Paths deeper than this level are skipped. Must be non-negative. No limit by default.",
+        help="Maximum directory depth to scan. Depth is counted from the source root at 0. Setting '--max-depth 0' results in no files being included, as depth 0 prunes immediately. Must be non-negative. No limit by default.",
     )
     parser.add_argument(
         "--include-binary-files",


### PR DESCRIPTION
## Summary
- support `--max-depth` in `m1f.py`
- document the option in README and usage examples
- test limiting directory traversal depth

## Testing
- `python -m py_compile tools/m1f.py tests/m1f/test_m1f.py`
- `pytest tests/m1f/test_m1f.py::TestM1F::test_max_depth -q` *(fails: command not found)*